### PR TITLE
BTC-E deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A Ruby gem for executing arbitrage between different Bitcoin exchanges. Supports
 
 - Bitstamp
 - CampBX
-- BTC-E
+- ~~BTC-E~~ (deprecated)
 - Coinbase
 - ~~MtGox~~ (deprecated)
+
 
 ## Meta
 


### PR DESCRIPTION
On the 28th of July 2017, US authorities seized the BTC-e.com domain name.